### PR TITLE
feat(goreleaser): change arm64 to aarch64

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ archives:
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- else }}aarch64{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:


### PR DESCRIPTION
need to use aarch64 instead of arm64 to match x86_64 and be able to use `uname -m`

you could choose to change x86_64 to amd64 instead and then use `dpkg --print-architecture`

this would simplify: https://github.com/jenkins-infra/docker-builder/pull/311